### PR TITLE
feature:TLY-104 metadata type 추가 및 테스트 구현

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,8 @@
       "Bash(docker exec:*)",
       "Bash(docker logs:*)",
       "Bash(./gradlew test:*)",
-      "Bash(./gradlew:*)"
+      "Bash(./gradlew:*)",
+      "Bash(grep:*)"
     ],
     "deny": [],
     "ask": []

--- a/notification-adapters/adapter-persistence/src/main/java/com/threadly/notification/adapter/persistence/notification/entity/NotificationEntity.java
+++ b/notification-adapters/adapter-persistence/src/main/java/com/threadly/notification/adapter/persistence/notification/entity/NotificationEntity.java
@@ -7,6 +7,8 @@ import com.threadly.notification.core.domain.notification.Notification;
 import com.threadly.notification.core.domain.notification.Notification.ActorProfile;
 import com.threadly.notification.core.domain.notification.NotificationType;
 import com.threadly.notification.core.domain.notification.metadata.CommentLikeMeta;
+import com.threadly.notification.core.domain.notification.metadata.FollowAcceptMeta;
+import com.threadly.notification.core.domain.notification.metadata.FollowMeta;
 import com.threadly.notification.core.domain.notification.metadata.FollowRequestMeta;
 import com.threadly.notification.core.domain.notification.metadata.NotificationMetaData;
 import com.threadly.notification.core.domain.notification.metadata.PostCommentMeta;
@@ -49,7 +51,10 @@ public class NotificationEntity {
       @JsonSubTypes.Type(value = PostLikeMeta.class, name = "POST_LIKE"),
       @JsonSubTypes.Type(value = PostCommentMeta.class, name = "COMMENT_ADDED"),
       @JsonSubTypes.Type(value = CommentLikeMeta.class, name = "COMMENT_LIKE"),
-      @JsonSubTypes.Type(value = FollowRequestMeta.class, name = "FOLLOW_REQUEST")
+      @JsonSubTypes.Type(value = FollowRequestMeta.class, name = "FOLLOW_REQUEST"),
+      @JsonSubTypes.Type(value = FollowMeta.class, name = "FOLLOW"),
+      @JsonSubTypes.Type(value = FollowAcceptMeta.class, name = "FOLLOW_ACCEPT")
+
   })
   private NotificationMetaData metadata;
 

--- a/notification-apps/app-api/src/test/java/com/threadly/notification/controller/BaseNotificationApiTest.java
+++ b/notification-apps/app-api/src/test/java/com/threadly/notification/controller/BaseNotificationApiTest.java
@@ -163,15 +163,15 @@ public class BaseNotificationApiTest extends BaseApiTest {
    */
   public NotificationEntity createTestNotification(String receiverId) {
     return createTestNotification(receiverId, UUID.randomUUID().toString(), "test-post",
-        "test-liker", "test-nickname", "https://test.com/profile.jpg");
+        "test-actor-user", "test-nickname", "https://test.com/profile.jpg");
   }
 
   /**
    * 테스트용 알림 엔티티 생성 (상세 설정)
    */
   public NotificationEntity createTestNotification(String receiverId, String eventId, String postId,
-      String likerId) {
-    return createTestNotification(receiverId, eventId, postId, likerId, "test-nickname",
+      String actorUserId) {
+    return createTestNotification(receiverId, eventId, postId, actorUserId, "test-nickname",
         "https://test.com/profile.jpg");
   }
 
@@ -179,9 +179,9 @@ public class BaseNotificationApiTest extends BaseApiTest {
    * 테스트용 알림 엔티티 생성 (전체 설정)
    */
   public NotificationEntity createTestNotification(String receiverId, String eventId, String postId,
-      String likerId, String nickname, String profileImageUrl) {
-    PostLikeMeta metadata = new PostLikeMeta(postId, likerId);
-    ActorProfile actorProfile = new ActorProfile(likerId, nickname, profileImageUrl);
+      String actorUserId, String nickname, String profileImageUrl) {
+    PostLikeMeta metadata = new PostLikeMeta(postId);
+    ActorProfile actorProfile = new ActorProfile(actorUserId, nickname, profileImageUrl);
 
     return new NotificationEntity(
         eventId,

--- a/notification-apps/app-api/src/test/java/com/threadly/notification/controller/DeleteNotificationApiTest.java
+++ b/notification-apps/app-api/src/test/java/com/threadly/notification/controller/DeleteNotificationApiTest.java
@@ -229,7 +229,7 @@ public class DeleteNotificationApiTest extends BaseNotificationApiTest {
         USER_STATUS_TYPE);
     String testEventId = "test-event-for-complete-removal";
     NotificationEntity notification = createTestNotification(VALID_USER_ID, testEventId,
-        "test-post", "test-liker", "test-nickname", "https://test.com/profile.jpg");
+        "test-post", "test-actor-user", "test-nickname", "https://test.com/profile.jpg");
     notificationRepository.save(notification);
 
     // 삭제 전 데이터 존재 확인

--- a/notification-apps/app-api/src/test/java/com/threadly/notification/controller/GetNotificationApiTest.java
+++ b/notification-apps/app-api/src/test/java/com/threadly/notification/controller/GetNotificationApiTest.java
@@ -59,7 +59,7 @@ public class GetNotificationApiTest extends BaseNotificationApiTest {
     // ActorProfile 검증
     ActorProfile actorProfile = data.actorProfile();
     assert actorProfile != null;
-    assert actorProfile.userId().equals("test-liker");
+    assert actorProfile.userId().equals("test-actor-user");
     assert actorProfile.nickname().equals("test-nickname");
     assert actorProfile.profileImageUrl().equals("https://test.com/profile.jpg");
   }
@@ -187,7 +187,7 @@ public class GetNotificationApiTest extends BaseNotificationApiTest {
     assert data.eventId().equals("event2");
     PostLikeMeta metadata = (PostLikeMeta) data.metaData();
     assert metadata.postId().equals("post2");
-    assert metadata.likerId().equals("liker2");
+    assert data.actorProfile().userId().equals("liker2");
     
     // ActorProfile 검증
     ActorProfile actorProfile = data.actorProfile();
@@ -223,7 +223,7 @@ public class GetNotificationApiTest extends BaseNotificationApiTest {
     // ActorProfile 검증
     ActorProfile actorProfile = data.actorProfile();
     assert actorProfile != null;
-    assert actorProfile.userId().equals("test-liker");
+    assert actorProfile.userId().equals("test-actor-user");
     assert actorProfile.nickname().equals("test-nickname");
     assert actorProfile.profileImageUrl().equals("https://test.com/profile.jpg");
   }
@@ -252,7 +252,7 @@ public class GetNotificationApiTest extends BaseNotificationApiTest {
     GetNotificationDetailsApiResponse data = response.getData();
     PostLikeMeta metadata = (PostLikeMeta) data.metaData();
     assert metadata.postId().equals(testPostId);
-    assert metadata.likerId().equals(testLikerId);
+    assert data.actorProfile().userId().equals(testLikerId);
     
     // ActorProfile 검증
     ActorProfile actorProfile = data.actorProfile();
@@ -302,7 +302,7 @@ public class GetNotificationApiTest extends BaseNotificationApiTest {
         USER_STATUS_TYPE);
     
     // ActorProfile이 null인 알림 생성
-    PostLikeMeta metadata = new PostLikeMeta("test-post", "test-liker");
+    PostLikeMeta metadata = new PostLikeMeta("test-post");
     NotificationEntity notification = new NotificationEntity(
         "null-profile-event",
         VALID_USER_ID,

--- a/notification-apps/app-api/src/test/java/com/threadly/notification/controller/GetNotificationsByCursorApiTest.java
+++ b/notification-apps/app-api/src/test/java/com/threadly/notification/controller/GetNotificationsByCursorApiTest.java
@@ -233,7 +233,7 @@ public class GetNotificationsByCursorApiTest extends BaseNotificationApiTest {
     String customProfileUrl = "https://test.com/custom.jpg";
 
     NotificationEntity notification = createTestNotification(VALID_USER_ID, "test-event",
-        "test-post", "test-liker", customNickname, customProfileUrl);
+        "test-post", "test-actor-user", customNickname, customProfileUrl);
     notificationRepository.save(notification);
 
     // when

--- a/notification-apps/app-api/src/test/java/com/threadly/notification/controller/MarkAsReadNotificationApiTest.java
+++ b/notification-apps/app-api/src/test/java/com/threadly/notification/controller/MarkAsReadNotificationApiTest.java
@@ -221,7 +221,7 @@ public class MarkAsReadNotificationApiTest extends BaseNotificationApiTest {
         USER_STATUS_TYPE);
     String testEventId = "persistent-test-event";
     NotificationEntity notification = createTestNotification(VALID_USER_ID, testEventId,
-        "test-post", "test-liker", "test-nickname", "https://test.com/profile.jpg");
+        "test-post", "test-actor-user", "test-nickname", "https://test.com/profile.jpg");
     notificationRepository.save(notification);
 
     // when

--- a/notification-apps/app-api/src/test/java/com/threadly/notification/controller/NotificationKafkaIntegrationTest.java
+++ b/notification-apps/app-api/src/test/java/com/threadly/notification/controller/NotificationKafkaIntegrationTest.java
@@ -45,7 +45,7 @@ public class NotificationKafkaIntegrationTest extends BaseNotificationApiTest {
     String likerId = "liker-789";
     
     NotificationEvent event = createPostLikeEvent(
-        eventId, VALID_USER_ID, ACTOR_USER_ID, "좋아요러", "https://test.com/profile.jpg", postId, likerId
+        eventId, VALID_USER_ID, ACTOR_USER_ID, "좋아요러", "https://test.com/profile.jpg", postId
     );
 
     // when - Kafka 이벤트 발신
@@ -83,7 +83,7 @@ public class NotificationKafkaIntegrationTest extends BaseNotificationApiTest {
     String likerId = "api-liker-123";
     
     NotificationEvent event = createPostLikeEvent(
-        eventId, VALID_USER_ID, ACTOR_USER_ID, "API테스터", "https://api-test.com/profile.jpg", postId, likerId
+        eventId, VALID_USER_ID, ACTOR_USER_ID, "API테스터", "https://api-test.com/profile.jpg", postId
     );
 
     // when - Kafka 이벤트 발신
@@ -129,9 +129,9 @@ public class NotificationKafkaIntegrationTest extends BaseNotificationApiTest {
     String eventId2 = "multi-event-002";
     String eventId3 = "multi-event-003";
     
-    NotificationEvent event1 = createPostLikeEvent(eventId1, VALID_USER_ID, "actor1", "액터1", "https://actor1.com/profile.jpg", "post1", "liker1");
-    NotificationEvent event2 = createPostLikeEvent(eventId2, VALID_USER_ID, "actor2", "액터2", "https://actor2.com/profile.jpg", "post2", "liker2");
-    NotificationEvent event3 = createPostLikeEvent(eventId3, VALID_USER_ID, "actor3", "액터3", "https://actor3.com/profile.jpg", "post3", "liker3");
+    NotificationEvent event1 = createPostLikeEvent(eventId1, VALID_USER_ID, "actor1", "액터1", "https://actor1.com/profile.jpg", "post1");
+    NotificationEvent event2 = createPostLikeEvent(eventId2, VALID_USER_ID, "actor2", "액터2", "https://actor2.com/profile.jpg", "post2");
+    NotificationEvent event3 = createPostLikeEvent(eventId3, VALID_USER_ID, "actor3", "액터3", "https://actor3.com/profile.jpg", "post3");
 
     // when - 다중 이벤트 발신
     sendKafkaTest(event1, status().isOk());
@@ -175,7 +175,7 @@ public class NotificationKafkaIntegrationTest extends BaseNotificationApiTest {
         NotificationType.POST_LIKE,
         LocalDateTime.now(),
         new ActorProfile(ACTOR_USER_ID, "테스터", "https://test.com/profile.jpg"),
-        createPostLikeMetadata("test-post", "test-liker")
+        createPostLikeMetadata("test-post")
     );
 
     // when - 잘못된 이벤트 발신
@@ -198,7 +198,7 @@ public class NotificationKafkaIntegrationTest extends BaseNotificationApiTest {
     String duplicateEventId = "duplicate-event-005";
     
     NotificationEvent event = createPostLikeEvent(
-        duplicateEventId, VALID_USER_ID, ACTOR_USER_ID, "중복테스터", "https://duplicate.com/profile.jpg", "duplicate-post", "duplicate-liker"
+        duplicateEventId, VALID_USER_ID, ACTOR_USER_ID, "중복테스터", "https://duplicate.com/profile.jpg", "duplicate-post"
     );
 
     // when - 동일한 이벤트 두 번 발신
@@ -233,7 +233,7 @@ public class NotificationKafkaIntegrationTest extends BaseNotificationApiTest {
       String eventId = "bulk-event-" + String.format("%03d", i);
       NotificationEvent event = createPostLikeEvent(
           eventId, VALID_USER_ID, "bulk-actor-" + i, "벌크액터" + i, 
-          "https://bulk.com/" + i + "/profile.jpg", "bulk-post-" + i, "bulk-liker-" + i
+          "https://bulk.com/" + i + "/profile.jpg", "bulk-post-" + i
       );
       sendKafkaTest(event, status().isOk());
     }
@@ -264,10 +264,10 @@ public class NotificationKafkaIntegrationTest extends BaseNotificationApiTest {
    * POST_LIKE 이벤트 생성 헬퍼 메서드
    */
   private NotificationEvent createPostLikeEvent(String eventId, String receiverUserId, 
-      String actorUserId, String actorNickname, String actorProfileUrl, String postId, String likerId) {
+      String actorUserId, String actorNickname, String actorProfileUrl, String postId) {
     
     ActorProfile actorProfile = new ActorProfile(actorUserId, actorNickname, actorProfileUrl);
-    Map<String, Object> metadata = createPostLikeMetadata(postId, likerId);
+    Map<String, Object> metadata = createPostLikeMetadata(postId);
     
     return new NotificationEvent(
         eventId,
@@ -282,10 +282,10 @@ public class NotificationKafkaIntegrationTest extends BaseNotificationApiTest {
   /**
    * POST_LIKE 메타데이터 생성 헬퍼 메서드
    */
-  private Map<String, Object> createPostLikeMetadata(String postId, String likerId) {
+  private Map<String, Object> createPostLikeMetadata(String postId) {
     Map<String, Object> metadata = new HashMap<>();
+    metadata.put("type", "POST_LIKE");
     metadata.put("postId", postId);
-    metadata.put("likerId", likerId);
     return metadata;
   }
 }

--- a/notification-apps/app-api/src/test/java/com/threadly/notification/controller/NotificationMetadataSerializationTest.java
+++ b/notification-apps/app-api/src/test/java/com/threadly/notification/controller/NotificationMetadataSerializationTest.java
@@ -1,0 +1,288 @@
+package com.threadly.notification.controller;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.threadly.notification.CommonResponse;
+import com.threadly.notification.adapter.kafka.notification.dto.NotificationEvent;
+import com.threadly.notification.adapter.persistence.notification.entity.NotificationEntity;
+import com.threadly.notification.core.domain.notification.Notification.ActorProfile;
+import com.threadly.notification.core.domain.notification.NotificationType;
+import com.threadly.notification.core.domain.notification.metadata.CommentLikeMeta;
+import com.threadly.notification.core.domain.notification.metadata.FollowAcceptMeta;
+import com.threadly.notification.core.domain.notification.metadata.FollowMeta;
+import com.threadly.notification.core.domain.notification.metadata.FollowRequestMeta;
+import com.threadly.notification.core.domain.notification.metadata.PostCommentMeta;
+import com.threadly.notification.core.domain.notification.metadata.PostLikeMeta;
+import com.threadly.notification.core.port.notification.in.dto.GetNotificationDetailsApiResponse;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("NotificationType별 메타데이터 JsonSubTypes 저장 테스트")
+public class NotificationMetadataSerializationTest extends BaseNotificationApiTest {
+
+  private static final String VALID_USER_ID = "user123";
+  private static final String ACTOR_USER_ID = "actor456";
+  private static final String USER_TYPE = "USER";
+  private static final String USER_STATUS_TYPE = "ACTIVE";
+
+  @AfterEach
+  void tearDown() {
+    notificationRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("POST_LIKE 메타데이터 저장 및 조회 테스트")
+  void testPostLikeMetadata() throws Exception {
+    String eventId = "post-like-meta-test";
+    String accessToken = accessTokenTestUtils.generateAccessToken(VALID_USER_ID, USER_TYPE, USER_STATUS_TYPE);
+    
+    NotificationEvent event = createNotificationEvent(
+        eventId, NotificationType.POST_LIKE, createPostLikeMetadata("post123")
+    );
+
+    sendKafkaTest(event, status().isOk());
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> {
+          Optional<NotificationEntity> savedEntity = notificationRepository.findByEventIdAndReceiverId(eventId, VALID_USER_ID);
+          assert savedEntity.isPresent();
+          assert savedEntity.get().getNotificationType() == NotificationType.POST_LIKE;
+        });
+
+    CommonResponse<GetNotificationDetailsApiResponse> response = getNotificationDetailsRequest(
+        accessToken, eventId, status().isOk());
+    
+    assert response.isSuccess();
+    assert response.getData().notificationType() == NotificationType.POST_LIKE;
+    
+    // 메타데이터 상세 검증
+    PostLikeMeta metadata = (PostLikeMeta) response.getData().metaData();
+    assert metadata != null;
+    assert metadata.postId().equals("post123");
+  }
+
+  @Test
+  @DisplayName("COMMENT_ADDED 메타데이터 저장 및 조회 테스트")
+  void testCommentAddedMetadata() throws Exception {
+    String eventId = "comment-added-meta-test";
+    String accessToken = accessTokenTestUtils.generateAccessToken(VALID_USER_ID, USER_TYPE, USER_STATUS_TYPE);
+    
+    NotificationEvent event = createNotificationEvent(
+        eventId, NotificationType.COMMENT_ADDED, createPostCommentMetadata("post456", "comment789", "좋은 글이네요!")
+    );
+
+    sendKafkaTest(event, status().isOk());
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> {
+          Optional<NotificationEntity> savedEntity = notificationRepository.findByEventIdAndReceiverId(eventId, VALID_USER_ID);
+          assert savedEntity.isPresent();
+          assert savedEntity.get().getNotificationType() == NotificationType.COMMENT_ADDED;
+        });
+
+    CommonResponse<GetNotificationDetailsApiResponse> response = getNotificationDetailsRequest(
+        accessToken, eventId, status().isOk());
+    
+    assert response.isSuccess();
+    assert response.getData().notificationType() == NotificationType.COMMENT_ADDED;
+    
+    // 메타데이터 상세 검증
+    PostCommentMeta metadata = (PostCommentMeta) response.getData().metaData();
+    assert metadata != null;
+    assert metadata.postId().equals("post456");
+    assert metadata.commentId().equals("comment789");
+    assert metadata.commentExcerpt().equals("좋은 글이네요!");
+  }
+
+  @Test
+  @DisplayName("COMMENT_LIKE 메타데이터 저장 및 조회 테스트")
+  void testCommentLikeMetadata() throws Exception {
+    String eventId = "comment-like-meta-test";
+    String accessToken = accessTokenTestUtils.generateAccessToken(VALID_USER_ID, USER_TYPE, USER_STATUS_TYPE);
+    
+    NotificationEvent event = createNotificationEvent(
+        eventId, NotificationType.COMMENT_LIKE, createCommentLikeMetadata("post789", "comment123", "멋진 댓글!")
+    );
+
+    sendKafkaTest(event, status().isOk());
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> {
+          Optional<NotificationEntity> savedEntity = notificationRepository.findByEventIdAndReceiverId(eventId, VALID_USER_ID);
+          assert savedEntity.isPresent();
+          assert savedEntity.get().getNotificationType() == NotificationType.COMMENT_LIKE;
+        });
+
+    CommonResponse<GetNotificationDetailsApiResponse> response = getNotificationDetailsRequest(
+        accessToken, eventId, status().isOk());
+    
+    assert response.isSuccess();
+    assert response.getData().notificationType() == NotificationType.COMMENT_LIKE;
+    
+    // 메타데이터 상세 검증
+    CommentLikeMeta metadata = (CommentLikeMeta) response.getData().metaData();
+    assert metadata != null;
+    assert metadata.postId().equals("post789");
+    assert metadata.commentId().equals("comment123");
+    assert metadata.commentExcerpt().equals("멋진 댓글!");
+  }
+
+  @Test
+  @DisplayName("FOLLOW_REQUEST 메타데이터 저장 및 조회 테스트")
+  void testFollowRequestMetadata() throws Exception {
+    String eventId = "follow-request-meta-test";
+    String accessToken = accessTokenTestUtils.generateAccessToken(VALID_USER_ID, USER_TYPE, USER_STATUS_TYPE);
+    
+    NotificationEvent event = createNotificationEvent(
+        eventId, NotificationType.FOLLOW_REQUEST, createFollowRequestMetadata()
+    );
+
+    sendKafkaTest(event, status().isOk());
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> {
+          Optional<NotificationEntity> savedEntity = notificationRepository.findByEventIdAndReceiverId(eventId, VALID_USER_ID);
+          assert savedEntity.isPresent();
+          assert savedEntity.get().getNotificationType() == NotificationType.FOLLOW_REQUEST;
+        });
+
+    CommonResponse<GetNotificationDetailsApiResponse> response = getNotificationDetailsRequest(
+        accessToken, eventId, status().isOk());
+    
+    assert response.isSuccess();
+    assert response.getData().notificationType() == NotificationType.FOLLOW_REQUEST;
+    
+    // 메타데이터 상세 검증 (FollowRequestMeta는 필드가 없음)
+    FollowRequestMeta metadata = (FollowRequestMeta) response.getData().metaData();
+    assert metadata != null;
+  }
+
+  @Test
+  @DisplayName("FOLLOW 메타데이터 저장 및 조회 테스트")
+  void testFollowMetadata() throws Exception {
+    String eventId = "follow-meta-test";
+    String accessToken = accessTokenTestUtils.generateAccessToken(VALID_USER_ID, USER_TYPE, USER_STATUS_TYPE);
+    
+    NotificationEvent event = createNotificationEvent(
+        eventId, NotificationType.FOLLOW, createFollowMetadata()
+    );
+
+    sendKafkaTest(event, status().isOk());
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> {
+          Optional<NotificationEntity> savedEntity = notificationRepository.findByEventIdAndReceiverId(eventId, VALID_USER_ID);
+          assert savedEntity.isPresent();
+          assert savedEntity.get().getNotificationType() == NotificationType.FOLLOW;
+        });
+
+    CommonResponse<GetNotificationDetailsApiResponse> response = getNotificationDetailsRequest(
+        accessToken, eventId, status().isOk());
+    
+    assert response.isSuccess();
+    assert response.getData().notificationType() == NotificationType.FOLLOW;
+    
+    // 메타데이터 상세 검증 (FollowMeta는 필드가 없음)
+    FollowMeta metadata = (FollowMeta) response.getData().metaData();
+    assert metadata != null;
+  }
+
+  @Test
+  @DisplayName("FOLLOW_ACCEPT 메타데이터 저장 및 조회 테스트")
+  void testFollowAcceptMetadata() throws Exception {
+    String eventId = "follow-accept-meta-test";
+    String accessToken = accessTokenTestUtils.generateAccessToken(VALID_USER_ID, USER_TYPE, USER_STATUS_TYPE);
+    
+    NotificationEvent event = createNotificationEvent(
+        eventId, NotificationType.FOLLOW_ACCEPT, createFollowAcceptMetadata()
+    );
+
+    sendKafkaTest(event, status().isOk());
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> {
+          Optional<NotificationEntity> savedEntity = notificationRepository.findByEventIdAndReceiverId(eventId, VALID_USER_ID);
+          assert savedEntity.isPresent();
+          assert savedEntity.get().getNotificationType() == NotificationType.FOLLOW_ACCEPT;
+        });
+
+    CommonResponse<GetNotificationDetailsApiResponse> response = getNotificationDetailsRequest(
+        accessToken, eventId, status().isOk());
+    
+    assert response.isSuccess();
+    assert response.getData().notificationType() == NotificationType.FOLLOW_ACCEPT;
+    
+    // 메타데이터 상세 검증 (FollowAcceptMeta는 필드가 없음)
+    FollowAcceptMeta metadata = (FollowAcceptMeta) response.getData().metaData();
+    assert metadata != null;
+  }
+
+  private NotificationEvent createNotificationEvent(String eventId, NotificationType type, Map<String, Object> metadata) {
+    ActorProfile actorProfile = new ActorProfile(ACTOR_USER_ID, "테스터", "https://test.com/profile.jpg");
+    
+    return new NotificationEvent(
+        eventId,
+        VALID_USER_ID,
+        type,
+        LocalDateTime.now(),
+        actorProfile,
+        metadata
+    );
+  }
+
+  private Map<String, Object> createPostLikeMetadata(String postId) {
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put("type", "POST_LIKE");
+    metadata.put("postId", postId);
+    return metadata;
+  }
+
+  private Map<String, Object> createPostCommentMetadata(String postId, String commentId, String commentExcerpt) {
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put("type", "COMMENT_ADDED");
+    metadata.put("postId", postId);
+    metadata.put("commentId", commentId);
+    metadata.put("commentExcerpt", commentExcerpt);
+    return metadata;
+  }
+
+  private Map<String, Object> createCommentLikeMetadata(String postId, String commentId, String commentExcerpt) {
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put("type", "COMMENT_LIKE");
+    metadata.put("postId", postId);
+    metadata.put("commentId", commentId);
+    metadata.put("commentExcerpt", commentExcerpt);
+    return metadata;
+  }
+
+  private Map<String, Object> createFollowRequestMetadata() {
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put("type", "FOLLOW_REQUEST");
+    return metadata;
+  }
+
+  private Map<String, Object> createFollowMetadata() {
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put("type", "FOLLOW");
+    return metadata;
+  }
+
+  private Map<String, Object> createFollowAcceptMetadata() {
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put("type", "FOLLOW_ACCEPT");
+    return metadata;
+  }
+}

--- a/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/notification/NotificationType.java
+++ b/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/notification/NotificationType.java
@@ -7,5 +7,7 @@ public enum NotificationType {
   POST_LIKE,
   COMMENT_ADDED,
   COMMENT_LIKE,
-  FOLLOW_REQUEST
+  FOLLOW_REQUEST,
+  FOLLOW,
+  FOLLOW_ACCEPT
 }

--- a/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/notification/metadata/CommentLikeMeta.java
+++ b/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/notification/metadata/CommentLikeMeta.java
@@ -1,7 +1,13 @@
 package com.threadly.notification.core.domain.notification.metadata;
 
+/**
+ * 게시글 댓글 좋아요 메타 데이터
+ * @param postId
+ * @param commentId
+ * @param commentExcerpt
+ */
 public record CommentLikeMeta(
-    String commentId, String likerId, String commentExcerpt
+    String postId, String commentId,  String commentExcerpt
 ) implements NotificationMetaData {
 
 }

--- a/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/notification/metadata/FollowAcceptMeta.java
+++ b/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/notification/metadata/FollowAcceptMeta.java
@@ -1,9 +1,9 @@
 package com.threadly.notification.core.domain.notification.metadata;
 
 /**
- * 팔로우 알림 메타 데이터
+ * 팔로우 수락 메타 데이터
  */
-public record FollowRequestMeta(
+public record FollowAcceptMeta(
 ) implements NotificationMetaData {
 
 }

--- a/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/notification/metadata/FollowMeta.java
+++ b/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/notification/metadata/FollowMeta.java
@@ -1,9 +1,10 @@
 package com.threadly.notification.core.domain.notification.metadata;
 
 /**
- * 팔로우 알림 메타 데이터
+ * 팔로우 메타 데이터
+ *
  */
-public record FollowRequestMeta(
+public record FollowMeta(
 ) implements NotificationMetaData {
 
 }

--- a/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/notification/metadata/NotificationMetaData.java
+++ b/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/notification/metadata/NotificationMetaData.java
@@ -4,6 +4,8 @@ package com.threadly.notification.core.domain.notification.metadata;
  * Notification metadata
  */
 public sealed interface NotificationMetaData
-  permits PostLikeMeta, PostCommentMeta, CommentLikeMeta, FollowRequestMeta
-{}
+    permits PostLikeMeta, PostCommentMeta, CommentLikeMeta, FollowRequestMeta, FollowMeta,
+    FollowAcceptMeta {
+
+}
 

--- a/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/notification/metadata/PostCommentMeta.java
+++ b/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/notification/metadata/PostCommentMeta.java
@@ -1,7 +1,13 @@
 package com.threadly.notification.core.domain.notification.metadata;
 
+/**
+ * 게시글 댓글 알림 메타 데이터
+ * @param postId
+ * @param commentId
+ * @param commentExcerpt
+ */
 public record PostCommentMeta(
-    String postId, String commentId, String commenterId, String commentExcerpt
+    String postId, String commentId, String commentExcerpt
 ) implements NotificationMetaData{
 
 }

--- a/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/notification/metadata/PostLikeMeta.java
+++ b/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/notification/metadata/PostLikeMeta.java
@@ -1,7 +1,12 @@
 package com.threadly.notification.core.domain.notification.metadata;
 
+/**
+ * 게시글 좋아요 메타 데이터
+ *
+ * @param postId
+ */
 public record PostLikeMeta(
-    String postId, String likerId
+    String postId
 ) implements NotificationMetaData {
 
 }

--- a/notification-core/core-port/src/main/java/com/threadly/notification/core/port/notification/in/dto/GetNotificationDetailsApiResponse.java
+++ b/notification-core/core-port/src/main/java/com/threadly/notification/core/port/notification/in/dto/GetNotificationDetailsApiResponse.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.threadly.notification.core.domain.notification.Notification.ActorProfile;
 import com.threadly.notification.core.domain.notification.NotificationType;
 import com.threadly.notification.core.domain.notification.metadata.CommentLikeMeta;
+import com.threadly.notification.core.domain.notification.metadata.FollowAcceptMeta;
+import com.threadly.notification.core.domain.notification.metadata.FollowMeta;
 import com.threadly.notification.core.domain.notification.metadata.FollowRequestMeta;
 import com.threadly.notification.core.domain.notification.metadata.NotificationMetaData;
 import com.threadly.notification.core.domain.notification.metadata.PostCommentMeta;
@@ -29,9 +31,11 @@ public record GetNotificationDetailsApiResponse(
     )
     @JsonSubTypes({
         @JsonSubTypes.Type(value = PostLikeMeta.class, name = "POST_LIKE"),
-        @JsonSubTypes.Type(value = PostCommentMeta.class, name = "POST_COMMENT"),
+        @JsonSubTypes.Type(value = PostCommentMeta.class, name = "COMMENT_ADDED"),
         @JsonSubTypes.Type(value = CommentLikeMeta.class, name = "COMMENT_LIKE"),
-        @JsonSubTypes.Type(value = FollowRequestMeta.class, name = "FOLLOW_REQUEST")
+        @JsonSubTypes.Type(value = FollowRequestMeta.class, name = "FOLLOW_REQUEST"),
+        @JsonSubTypes.Type(value = FollowMeta.class, name = "FOLLOW"),
+        @JsonSubTypes.Type(value = FollowAcceptMeta.class, name = "FOLLOW_ACCEPT")
     })
     NotificationMetaData metaData
 ) {

--- a/notification-core/core-service/src/main/java/com/threadly/notification/core/service/utils/MetadataMapper.java
+++ b/notification-core/core-service/src/main/java/com/threadly/notification/core/service/utils/MetadataMapper.java
@@ -3,6 +3,8 @@ package com.threadly.notification.core.service.utils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.threadly.notification.core.domain.notification.NotificationType;
 import com.threadly.notification.core.domain.notification.metadata.CommentLikeMeta;
+import com.threadly.notification.core.domain.notification.metadata.FollowAcceptMeta;
+import com.threadly.notification.core.domain.notification.metadata.FollowMeta;
 import com.threadly.notification.core.domain.notification.metadata.FollowRequestMeta;
 import com.threadly.notification.core.domain.notification.metadata.NotificationMetaData;
 import com.threadly.notification.core.domain.notification.metadata.PostCommentMeta;
@@ -30,6 +32,8 @@ public class MetadataMapper {
       case COMMENT_ADDED -> PostCommentMeta.class;
       case COMMENT_LIKE -> CommentLikeMeta.class;
       case FOLLOW_REQUEST -> FollowRequestMeta.class;
+      case FOLLOW_ACCEPT -> FollowAcceptMeta.class;
+      case FOLLOW -> FollowMeta.class;
     };
     return objectMapper.convertValue(raw, clazz);
   }


### PR DESCRIPTION
## 개요
- NotificationType 확장 및 메타데이터 구조 개선을 통한 다양한 알림 유형 지원
- PostLikeMeta 필드 간소화 및 JsonSubTypes 직렬화 일관성 확보
- 확장된 알림 타입에 대한 포괄적인 테스트 구현으로 안정성 보장

## 주요 변경 사항
### 1. NotificationType 확장
- 기존 4가지 타입에서 6가지 타입으로 확장
  - 기존: `POST_LIKE`, `COMMENT_ADDED`, `COMMENT_LIKE`, `FOLLOW_REQUEST`
  - 추가: `FOLLOW`, `FOLLOW_ACCEPT`
- 팔로우 관련 알림 세분화를 통한 사용자 경험 개선

### 2. 메타데이터 구조 개선
- `PostLikeMeta` 필드 간소화
  - 변경 전: `postId`, `likerId`
  - 변경 후: `postId`만 유지
  - ActorProfile을 통해 행위자 정보 관리로 중복 제거
- 새로운 메타데이터 클래스 추가
  - `FollowMeta`: 팔로우 알림용 (필드 없음)
  - `FollowAcceptMeta`: 팔로우 수락 알림용 (필드 없음)

### 3. Jackson 직렬화 일관성 확보
- `NotificationEntity`와 `GetNotificationDetailsApiResponse`의 `@JsonSubTypes` 설정 동기화
  - `POST_COMMENT` → `COMMENT_ADDED` 통일
  - 누락되었던 `FOLLOW`, `FOLLOW_ACCEPT` 타입 추가
- 모든 알림 타입의 JSON 직렬화/역직렬화 정상 작동 보장

### 4. 포괄적인 테스트 구현
- `NotificationMetadataSerializationTest` 신규 구현
  - 6가지 NotificationType별 Kafka → DB → API 검증
  - 메타데이터 필드값 정확성 검증
  - JsonSubTypes 직렬화 동작 확인
- 기존 테스트 코드 전면 수정
  - `PostLikeMeta` 필드 변경에 따른 테스트 데이터 수정
  - 테스트 헬퍼 메서드 파라미터 정리 (`likerId` → `actorUserId`)
  - Jackson 직렬화를 위한 `type` 필드 추가

### 5. 메타데이터 매핑 로직 확장
- `MetadataMapper`에 새로운 알림 타입 매핑 로직 추가
- 각 NotificationType에 맞는 메타데이터 생성 로직 구현

## 고려사항
- 알림 타입 확장성
  - 새로운 알림 타입 추가 시 JsonSubTypes 설정 동기화 필요
  - 메타데이터 구조 변경 시 기존 데이터와의 호환성 검토

- 테스트 커버리지
  - 모든 NotificationType에 대한 E2E 테스트 완료
  - 메타데이터 직렬화 안정성 검증 완료