### PR TITLE
feat: TLY-109 메일 전송 기능 구현

### DIFF
--- a/notification-adapters/adapter-kafka/src/main/java/com/threadly/notification/adapter/kafka/mail/MailConsumer.java
+++ b/notification-adapters/adapter-kafka/src/main/java/com/threadly/notification/adapter/kafka/mail/MailConsumer.java
@@ -1,27 +1,40 @@
-//package com.threadly.notification.adapter.kafka.mail;
-//
-//import com.threadly.notification.core.port.mail.in.MailIngestionUseCase;
-//import java.util.function.Consumer;
-//import lombok.RequiredArgsConstructor;
-//import lombok.extern.slf4j.Slf4j;
-//import org.apache.kafka.common.protocol.Message;
-//import org.springframework.context.annotation.Bean;
-//import org.springframework.stereotype.Component;
-//
-///**
-// * Kafka 메일 이벤트 수신 consumer
-// */
-//@Component
-//@RequiredArgsConstructor
-//@Slf4j
-//public class MailConsumer {
-//
-//  private final MailIngestionUseCase mailIngestionUseCase;
-//
-//  @Bean("mail")
-//  public Consumer<Message<MailEvent>> mailEventConsumer() {
-//
-//  }
-//
-//
-//}
+package com.threadly.notification.adapter.kafka.mail;
+
+import com.threadly.notification.adapter.kafka.mail.dto.MailEvent;
+import com.threadly.notification.core.port.mail.in.SendMailUseCase;
+import java.util.function.Consumer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.stereotype.Component;
+
+/**
+ * Kafka 메일 이벤트 수신 consumer
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MailConsumer {
+
+  private final SendMailUseCase sendMailUseCase;
+
+  @Bean("mail")
+  public Consumer<Message<MailEvent>> mailEventConsumer() {
+    return message -> {
+      Object rawKey = message.getHeaders().get(KafkaHeaders.RECEIVED_KEY);
+      MailEvent event = message.getPayload();
+
+      log.debug("Processing mail - key: {}, eventId: {}", rawKey, event.eventId());
+
+      /*key 검증*/
+      if (rawKey != null && !rawKey.equals(event.to())) {
+        log.warn("key 불일치 - key: {}, receiverId: {}", rawKey, event.to());
+      } else {
+        sendMailUseCase.send(event.toCommand());
+      }
+    };
+
+  }
+}

--- a/notification-adapters/adapter-kafka/src/main/java/com/threadly/notification/adapter/kafka/mail/MailConsumer.java
+++ b/notification-adapters/adapter-kafka/src/main/java/com/threadly/notification/adapter/kafka/mail/MailConsumer.java
@@ -1,0 +1,27 @@
+//package com.threadly.notification.adapter.kafka.mail;
+//
+//import com.threadly.notification.core.port.mail.in.MailIngestionUseCase;
+//import java.util.function.Consumer;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.apache.kafka.common.protocol.Message;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.stereotype.Component;
+//
+///**
+// * Kafka 메일 이벤트 수신 consumer
+// */
+//@Component
+//@RequiredArgsConstructor
+//@Slf4j
+//public class MailConsumer {
+//
+//  private final MailIngestionUseCase mailIngestionUseCase;
+//
+//  @Bean("mail")
+//  public Consumer<Message<MailEvent>> mailEventConsumer() {
+//
+//  }
+//
+//
+//}

--- a/notification-adapters/adapter-kafka/src/main/java/com/threadly/notification/adapter/kafka/mail/dto/MailEvent.java
+++ b/notification-adapters/adapter-kafka/src/main/java/com/threadly/notification/adapter/kafka/mail/dto/MailEvent.java
@@ -1,0 +1,31 @@
+package com.threadly.notification.adapter.kafka.mail.dto;
+
+
+import com.threadly.notification.core.domain.mail.MailType;
+import com.threadly.notification.core.port.mail.in.dto.SendMailCommand;
+import java.util.Map;
+
+/**
+ * Kafka Mail event 객체
+ */
+public record MailEvent(
+    String eventId,
+    MailType mailType,
+    String to,
+    Map<String, Object> model
+) {
+
+  /**
+   * event -> command
+   *
+   * @return
+   */
+  public SendMailCommand toCommand() {
+    return new SendMailCommand(
+        this.mailType,
+        this.to,
+        this.model
+    );
+  }
+
+}

--- a/notification-adapters/adapter-kafka/src/main/java/com/threadly/notification/adapter/kafka/test/KafkaTestProducer.java
+++ b/notification-adapters/adapter-kafka/src/main/java/com/threadly/notification/adapter/kafka/test/KafkaTestProducer.java
@@ -1,4 +1,4 @@
-package com.threadly.notification.adapter.kafka.kafka;
+package com.threadly.notification.adapter.kafka.test;
 
 import com.threadly.notification.adapter.kafka.notification.dto.NotificationEvent;
 import com.threadly.notification.core.port.test.dto.NotificationTestCommand;

--- a/notification-adapters/adapter-kafka/src/main/resources/application-kafka.yml
+++ b/notification-adapters/adapter-kafka/src/main/resources/application-kafka.yml
@@ -1,7 +1,7 @@
 spring:
   cloud:
     function:
-      definition: notification
+      definition: notification; mail;
     stream:
       bindings:
         notification-in-0:
@@ -11,10 +11,25 @@ spring:
           consumer:
             use-native-decoding: true
             max-attempts: 2
+        mail-in-0:
+          destination: mail
+          group: mail-consumer
+          content-type: application/json
+          consumer:
+            use-native-decoding: true
+            max-attempts: 2
       kafka:
         binder:
           brokers: localhost:9092
         bindings:
+          mail-in-0:
+            consumer:
+              configuration:
+                key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+                value.deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+                spring.json.trusted.packages: com.threadly.notification.adapter.kafka.mail.dto
+                spring.json.use.type.headers: false
+                spring.json.value.default.type: com.threadly.notification.adapter.kafka.mail.dto.MailEvent
           notification-in-0:
             consumer:
               configuration:

--- a/notification-adapters/adapter-smtp/build.gradle.kts
+++ b/notification-adapters/adapter-smtp/build.gradle.kts
@@ -1,0 +1,12 @@
+dependencies {
+
+    implementation(project(":notification-core:core-port"))
+    implementation(project(":notification-core:core-domain"))
+    
+    implementation(project(":notification-commons"))
+
+    /*mail*/
+    implementation("org.springframework.boot:spring-boot-starter-mail")
+    implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+
+}

--- a/notification-adapters/adapter-smtp/build.gradle.kts
+++ b/notification-adapters/adapter-smtp/build.gradle.kts
@@ -7,6 +7,5 @@ dependencies {
 
     /*mail*/
     implementation("org.springframework.boot:spring-boot-starter-mail")
-    implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
 
 }

--- a/notification-adapters/adapter-smtp/gradle.properties
+++ b/notification-adapters/adapter-smtp/gradle.properties
@@ -1,0 +1,1 @@
+label=java,library

--- a/notification-adapters/adapter-smtp/src/main/java/com/threadly/notification/adapter/smtp/SmtpModule.java
+++ b/notification-adapters/adapter-smtp/src/main/java/com/threadly/notification/adapter/smtp/SmtpModule.java
@@ -1,0 +1,5 @@
+package com.threadly.notification.adapter.smtp;
+
+public interface SmtpModule {
+
+}

--- a/notification-adapters/adapter-smtp/src/main/java/com/threadly/notification/adapter/smtp/client/MailClient.java
+++ b/notification-adapters/adapter-smtp/src/main/java/com/threadly/notification/adapter/smtp/client/MailClient.java
@@ -1,0 +1,97 @@
+package com.threadly.notification.adapter.smtp.client;
+
+import com.threadly.notification.commons.exception.ErrorCode;
+import com.threadly.notification.commons.exception.mail.EmailVerificationException;
+import com.threadly.notification.core.port.mail.out.SendMailPort;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MailClient implements SendMailPort {
+
+  private final JavaMailSender mailSender;
+  private final TemplateEngine templateEngine;
+
+  private final static String FROM = "rlarbqor00@naver.com";
+
+  @Value("${properties.email.verification-url}")
+  private String emailVerificationUrl;
+
+  @Override
+  public void sendVerificationMail(String to, String code) {
+
+    String verifyUrl = emailVerificationUrl + "/api/auth/verify-email?code=" + code;
+
+    Map<String, Object> values = new HashMap<>();
+    values.put("verifyUrl", verifyUrl);
+
+    String subject = "[Threadly] 본인 인증을 위한 메일입니다.";
+    String context = getContext(values, "verify-email-mail");
+
+    try {
+      sendMail(subject, context);
+
+      log.info("인증 메일 전송 완료");
+      log.debug("verifyUrl : " + verifyUrl);
+
+    } catch (Exception e) {
+      throw new EmailVerificationException(ErrorCode.EMAIL_SENDING_FAILED);
+    }
+
+  }
+
+  @Override
+  public void sendWelcomeMail(String to, String userName) {
+    try {
+      String subject = "[" + userName + "] 님 가입을 진심으로 환영합니다.";
+      String context = getContext(null, "signup-complete-mail");
+
+      sendMail(subject, context);
+
+      log.info("인증 확인 메일 전송 완료");
+    } catch (Exception e) {
+      throw new EmailVerificationException(ErrorCode.EMAIL_SENDING_FAILED);
+    }
+
+  }
+
+  /**
+   * mail 전송
+   *
+   * @param subject
+   * @param context
+   * @throws MessagingException
+   */
+  private void sendMail(String subject, String context)
+      throws MessagingException {
+    MimeMessage mimeMessage = mailSender.createMimeMessage();
+    MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+    helper.setFrom(FROM);
+    helper.setTo(FROM);
+    helper.setSubject(subject);
+    helper.setText(context, true);
+
+    mailSender.send(mimeMessage);
+  }
+
+
+  private String getContext(Map<String, Object> values, String template) {
+    Context context = new Context();
+    context.setVariables(values);
+
+    return templateEngine.process(template, context);
+  }
+
+}

--- a/notification-apps/app-api/build.gradle.kts
+++ b/notification-apps/app-api/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
     implementation(project(":notification-adapters:adapter-kafka"))
     implementation(project(":notification-adapters:adapter-persistence"))
     implementation(project(":notification-adapters:adapter-redis"))
+    implementation(project(":notification-adapters:adapter-smtp"))
 
     implementation(project(":notification-commons"))
 

--- a/notification-apps/app-api/src/main/resources/application-dev.yml
+++ b/notification-apps/app-api/src/main/resources/application-dev.yml
@@ -1,6 +1,6 @@
 spring:
   config:
-    import: 
+    import:
       - classpath:application-kafka.yml
       - classpath:application-persistence.yml
 
@@ -8,3 +8,8 @@ logging:
   level:
     com.threadly.notification: DEBUG
     org.apache.kafka: WARN
+
+properties:
+  email:
+    verification-url: http://localhost:8080
+

--- a/notification-apps/app-api/src/main/resources/application.yml
+++ b/notification-apps/app-api/src/main/resources/application.yml
@@ -4,9 +4,21 @@ spring:
       - classpath:application-kafka.yml
       - classpath:application-persistence.yml
       - classpath:application-redis-test.yml
+  mail:
+    host: smtp.naver.com
+    port: 587
+    username: ${MAIL.NAME}
+    password: ${MAIL.PASSWORD}
+    properties:
+      mail:
+        smtp:
+          debug: true
+          auth: true
+        starttls:
+          enable: true
 
-  # Profile 설정
-  profiles:
-    active: dev
+mail:
+  from: rlarbqor00@naver.com
+
 server:
   port: 8081

--- a/notification-commons/src/main/java/com/threadly/notification/commons/exception/mail/EmailVerificationException.java
+++ b/notification-commons/src/main/java/com/threadly/notification/commons/exception/mail/EmailVerificationException.java
@@ -1,0 +1,21 @@
+package com.threadly.notification.commons.exception.mail;
+
+
+import com.threadly.notification.commons.exception.ErrorCode;
+
+/**
+ * 메일 전송 관련 예외
+ */
+public class EmailVerificationException extends RuntimeException {
+
+  private ErrorCode errorCode;
+
+  public EmailVerificationException(ErrorCode errorCode) {
+    super(errorCode.getDesc());
+    this.errorCode = errorCode;
+  }
+
+  public ErrorCode getErrorCode() {
+    return errorCode;
+  }
+}

--- a/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/mail/MailType.java
+++ b/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/mail/MailType.java
@@ -1,0 +1,11 @@
+package com.threadly.notification.core.domain.mail;
+
+/**
+ * 메일 타입
+ */
+public enum MailType {
+  VERIFICATION,  //인증 메일
+  WELCOME // 가입 환영 메일
+
+
+}

--- a/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/mail/model/MailModel.java
+++ b/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/mail/model/MailModel.java
@@ -1,0 +1,10 @@
+package com.threadly.notification.core.domain.mail.model;
+
+/**
+ * 메일 모델
+ */
+public interface MailModel {
+
+  String userName();
+
+}

--- a/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/mail/model/VerificationModel.java
+++ b/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/mail/model/VerificationModel.java
@@ -1,0 +1,14 @@
+package com.threadly.notification.core.domain.mail.model;
+
+public record VerificationModel(
+    String userName,
+    String verificationUrl
+)
+    implements MailModel {
+
+
+  @Override
+  public String userName() {
+    return userName;
+  }
+}

--- a/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/mail/model/WelcomeModel.java
+++ b/notification-core/core-domain/src/main/java/com/threadly/notification/core/domain/mail/model/WelcomeModel.java
@@ -1,0 +1,17 @@
+package com.threadly.notification.core.domain.mail.model;
+
+/**
+ * 환영 메일 model
+ * @param userName
+ * @param loginUrl
+ */
+public record WelcomeModel(
+    String userName,
+    String loginUrl
+) implements MailModel {
+
+  @Override
+  public String userName() {
+    return userName;
+  }
+}

--- a/notification-core/core-port/src/main/java/com/threadly/notification/core/port/mail/in/MailIngestionUseCase.java
+++ b/notification-core/core-port/src/main/java/com/threadly/notification/core/port/mail/in/MailIngestionUseCase.java
@@ -1,0 +1,8 @@
+package com.threadly.notification.core.port.mail.in;
+
+/**
+ * 메일  이벤트 저장 처리 usecase
+ */
+public interface MailIngestionUseCase {
+
+}

--- a/notification-core/core-port/src/main/java/com/threadly/notification/core/port/mail/in/MailIngestionUseCase.java
+++ b/notification-core/core-port/src/main/java/com/threadly/notification/core/port/mail/in/MailIngestionUseCase.java
@@ -1,8 +1,0 @@
-package com.threadly.notification.core.port.mail.in;
-
-/**
- * 메일  이벤트 저장 처리 usecase
- */
-public interface MailIngestionUseCase {
-
-}

--- a/notification-core/core-port/src/main/java/com/threadly/notification/core/port/mail/in/SendMailUseCase.java
+++ b/notification-core/core-port/src/main/java/com/threadly/notification/core/port/mail/in/SendMailUseCase.java
@@ -1,0 +1,11 @@
+package com.threadly.notification.core.port.mail.in;
+
+import com.threadly.notification.core.port.mail.in.dto.SendMailCommand;
+
+/**
+ * 메일  이벤트 저장 처리 usecase
+ */
+public interface SendMailUseCase {
+
+  void send(SendMailCommand command);
+}

--- a/notification-core/core-port/src/main/java/com/threadly/notification/core/port/mail/in/dto/MailCommand.java
+++ b/notification-core/core-port/src/main/java/com/threadly/notification/core/port/mail/in/dto/MailCommand.java
@@ -1,5 +1,0 @@
-package com.threadly.notification.core.port.mail.in.dto;
-
-public record MailCommand() {
-
-}

--- a/notification-core/core-port/src/main/java/com/threadly/notification/core/port/mail/in/dto/MailCommand.java
+++ b/notification-core/core-port/src/main/java/com/threadly/notification/core/port/mail/in/dto/MailCommand.java
@@ -1,0 +1,5 @@
+package com.threadly.notification.core.port.mail.in.dto;
+
+public record MailCommand() {
+
+}

--- a/notification-core/core-port/src/main/java/com/threadly/notification/core/port/mail/in/dto/SendMailCommand.java
+++ b/notification-core/core-port/src/main/java/com/threadly/notification/core/port/mail/in/dto/SendMailCommand.java
@@ -1,0 +1,15 @@
+package com.threadly.notification.core.port.mail.in.dto;
+
+import com.threadly.notification.core.domain.mail.MailType;
+import java.util.Map;
+
+/**
+ * 메일 전송 command
+ */
+public record SendMailCommand(
+    MailType mailType,
+    String to,
+    Map<String, Object> model
+) {
+
+}

--- a/notification-core/core-port/src/main/java/com/threadly/notification/core/port/mail/out/SendMailPort.java
+++ b/notification-core/core-port/src/main/java/com/threadly/notification/core/port/mail/out/SendMailPort.java
@@ -1,0 +1,12 @@
+package com.threadly.notification.core.port.mail.out;
+
+/**
+ * 메일 전송 port
+ */
+public interface SendMailPort {
+
+  void sendVerificationMail(String to, String code);
+
+  void sendWelcomeMail(String to, String userName);
+
+}

--- a/notification-core/core-port/src/main/java/com/threadly/notification/core/port/mail/out/SendMailPort.java
+++ b/notification-core/core-port/src/main/java/com/threadly/notification/core/port/mail/out/SendMailPort.java
@@ -5,8 +5,11 @@ package com.threadly.notification.core.port.mail.out;
  */
 public interface SendMailPort {
 
-  void sendVerificationMail(String to, String code);
-
-  void sendWelcomeMail(String to, String userName);
-
+  /**
+   * 메일 전송
+   *
+   * @param subject
+   * @param context
+   */
+  void sendMail(String to, String subject, String context);
 }

--- a/notification-core/core-port/src/main/java/com/threadly/notification/core/port/notification/in/NotificationCommandUseCase.java
+++ b/notification-core/core-port/src/main/java/com/threadly/notification/core/port/notification/in/NotificationCommandUseCase.java
@@ -5,11 +5,6 @@ package com.threadly.notification.core.port.notification.in;
  */
 public interface NotificationCommandUseCase {
 
-  /**
-   * usecase 이동 고려
-   * @param command
-   */
-  void handleNotificationEvent(NotificationCommand command);
 
   /**
    * 주어진 eventId에 해당하는 알림 데이터 삭제

--- a/notification-core/core-port/src/main/java/com/threadly/notification/core/port/notification/in/NotificationIngestionUseCase.java
+++ b/notification-core/core-port/src/main/java/com/threadly/notification/core/port/notification/in/NotificationIngestionUseCase.java
@@ -1,0 +1,15 @@
+package com.threadly.notification.core.port.notification.in;
+
+/**
+ * 알림 이벤트 저장 처리 usecase
+ */
+public interface NotificationIngestionUseCase {
+
+  /**
+   * 알림 이벤트 저장
+   *
+   * @param command
+   */
+  void ingest(NotificationCommand command);
+
+}

--- a/notification-core/core-service/build.gradle.kts
+++ b/notification-core/core-service/build.gradle.kts
@@ -6,8 +6,7 @@ dependencies {
 
 
     implementation("org.springframework:spring-context")
-
     implementation("org.springframework.boot:spring-boot-starter-web")
-
+    implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
 
 }

--- a/notification-core/core-service/src/main/java/com/threadly/notification/core/service/mail/SendMailService.java
+++ b/notification-core/core-service/src/main/java/com/threadly/notification/core/service/mail/SendMailService.java
@@ -1,0 +1,100 @@
+package com.threadly.notification.core.service.mail;
+
+import com.threadly.notification.commons.exception.ErrorCode;
+import com.threadly.notification.commons.exception.mail.EmailVerificationException;
+import com.threadly.notification.core.domain.mail.model.VerificationModel;
+import com.threadly.notification.core.domain.mail.model.WelcomeModel;
+import com.threadly.notification.core.port.mail.in.SendMailUseCase;
+import com.threadly.notification.core.port.mail.in.dto.SendMailCommand;
+import com.threadly.notification.core.port.mail.out.SendMailPort;
+import com.threadly.notification.core.service.utils.MailModelMapper;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SendMailService implements SendMailUseCase {
+
+  private final SendMailPort sendMailPort;
+  private final MailModelMapper mailModelMapper;
+  private final TemplateEngine templateEngine;
+
+  @Override
+  public void send(SendMailCommand command) {
+    switch (command.mailType()) {
+      case WELCOME -> {
+        log.info("가입 환영 메일 전송: mailType={}, to={}", command.mailType(), command.to());
+        sendWelcomeMail(command);
+      }
+      case VERIFICATION -> {
+        log.info("인증 메일 전송: mailType={}, to={}", command.mailType(), command.to());
+        sendVerificationMail(command);
+      }
+    }
+  }
+
+  /**
+   * 가입 환영 메일 전송
+   *
+   * @param command
+   */
+  private void sendWelcomeMail(SendMailCommand command) {
+    WelcomeModel model = mailModelMapper.toTypeModel(command);
+
+    String subject = "[" + model.userName() + "] 님 가입을 환엽합니다.";
+    String context = getContext(null, "signup-complete-mail");
+
+    sendMail(command.to(), subject, context);
+  }
+
+  /**
+   * 인증 메일 전송
+   */
+  private void sendVerificationMail(SendMailCommand command) {
+    VerificationModel model = mailModelMapper.toTypeModel(command);
+
+    Map<String, Object> values = new HashMap<>();
+    values.put("verifyUrl", model.verificationUrl());
+
+    String subject = "[Threadly] 본인 인증을 위한 이메일입니다.";
+    String context = getContext(values, "verify-email-mail");
+
+    sendMail(command.to(), subject, context);
+  }
+
+  /**
+   * 메일 발송
+   *
+   * @param to
+   * @param subject
+   * @param context
+   */
+  private void sendMail(String to, String subject, String context) {
+    try {
+      sendMailPort.sendMail(to, subject, context);
+    } catch (Exception e) {
+      log.error("메일 전송 실패, error={}", e.getMessage());
+      throw new EmailVerificationException(ErrorCode.EMAIL_SENDING_FAILED);
+    }
+  }
+
+  /**
+   * 주어진 map으로 context 생성
+   *
+   * @param values
+   * @param template
+   * @return
+   */
+  private String getContext(Map<String, Object> values, String template) {
+    Context context = new Context();
+    context.setVariables(values);
+
+    return templateEngine.process(template, context);
+  }
+}

--- a/notification-core/core-service/src/main/java/com/threadly/notification/core/service/notification/NotificationCommandService.java
+++ b/notification-core/core-service/src/main/java/com/threadly/notification/core/service/notification/NotificationCommandService.java
@@ -6,6 +6,7 @@ import com.threadly.notification.core.domain.notification.Notification;
 import com.threadly.notification.core.domain.notification.Notification.ActorProfile;
 import com.threadly.notification.core.port.notification.in.NotificationCommand;
 import com.threadly.notification.core.port.notification.in.NotificationCommandUseCase;
+import com.threadly.notification.core.port.notification.in.NotificationIngestionUseCase;
 import com.threadly.notification.core.port.notification.out.NotificationCommandPort;
 import com.threadly.notification.core.port.notification.out.NotificationQueryPort;
 import com.threadly.notification.core.service.utils.MetadataMapper;
@@ -16,7 +17,8 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class NotificationCommandService implements NotificationCommandUseCase {
+public class NotificationCommandService implements NotificationCommandUseCase,
+    NotificationIngestionUseCase {
 
   private final NotificationCommandPort notificationCommandPort;
   private final NotificationQueryPort notificationQueryPort;
@@ -24,7 +26,7 @@ public class NotificationCommandService implements NotificationCommandUseCase {
   private final MetadataMapper metadataMapper;
 
   @Override
-  public void handleNotificationEvent(NotificationCommand command) {
+  public void ingest(NotificationCommand command) {
     log.info("Handling notification event: {}", command.toString());
     /*알림 저장*/
     Notification notification = Notification.newNotification(

--- a/notification-core/core-service/src/main/java/com/threadly/notification/core/service/utils/MailModelMapper.java
+++ b/notification-core/core-service/src/main/java/com/threadly/notification/core/service/utils/MailModelMapper.java
@@ -1,0 +1,37 @@
+package com.threadly.notification.core.service.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.threadly.notification.core.domain.mail.MailType;
+import com.threadly.notification.core.domain.mail.model.MailModel;
+import com.threadly.notification.core.domain.mail.model.VerificationModel;
+import com.threadly.notification.core.domain.mail.model.WelcomeModel;
+import com.threadly.notification.core.port.mail.in.dto.SendMailCommand;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Mail model 매퍼
+ */
+@Component
+@RequiredArgsConstructor
+public class MailModelMapper {
+
+  private final ObjectMapper objectMapper;
+
+  /**
+   * 주어진 type에 해당하는 model로 변경
+   *
+   * @param command
+   * @return
+   */
+  public <T extends MailModel> T toTypeModel(SendMailCommand command) {
+    Class<? extends MailModel> clazz = switch (command.mailType()) {
+      case WELCOME -> WelcomeModel.class;
+      case VERIFICATION -> VerificationModel.class;
+    };
+
+    return (T) objectMapper.convertValue(command.model(), clazz);
+  }
+
+}

--- a/notification-core/core-service/src/main/resources/templates/signup-complete-mail.html
+++ b/notification-core/core-service/src/main/resources/templates/signup-complete-mail.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>Threadly 가입을 환영합니다!</title>
+</head>
+<body style="margin:0; padding:0; font-family:Arial, sans-serif; background-color:#f4f4f4;">
+<table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#f4f4f4; padding: 40px 0;">
+  <tr>
+    <td align="center">
+      <table width="480" cellpadding="0" cellspacing="0" border="0" style="background-color:#ffffff; padding: 24px; border-radius: 8px;">
+        <tr>
+          <td style="text-align: center; font-size: 22px; font-weight: bold; color: #4f46e5; padding-bottom: 12px;">
+            Threadly 가입을 환영합니다! 🎉
+          </td>
+        </tr>
+        <tr>
+          <td style="text-align: center; font-size: 16px; color: #333333; padding-bottom: 24px;">
+            Threadly에 오신 걸 진심으로 환영합니다.<br/>
+            다양한 실시간 토론과 이야기를 지금 바로 시작해보세요!
+          </td>
+        </tr>
+        <tr>
+          <td align="center">
+            <a href="https://threadly.com/login" style="display: inline-block; padding: 12px 24px; background-color: #4f46e5; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 16px;">
+              로그인 하러 가기
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <td style="text-align: center; font-size: 12px; color: #999999; padding-top: 32px;">
+            이 메일은 시스템에 의해 자동 발송되었습니다.
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/notification-core/core-service/src/main/resources/templates/verify-email-complete-page.html
+++ b/notification-core/core-service/src/main/resources/templates/verify-email-complete-page.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>Threadly | 이메일 인증 완료</title>
+  <style>
+    body {
+      font-family: 'Pretendard', sans-serif;
+      background-color: #f9fafb;
+      margin: 0;
+      padding: 0;
+    }
+
+    .container {
+      max-width: 480px;
+      margin: 100px auto;
+      padding: 40px 24px;
+      background-color: #ffffff;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+      text-align: center;
+    }
+
+    .title {
+      font-size: 24px;
+      font-weight: 700;
+      color: #4f46e5;
+      margin-bottom: 16px;
+    }
+
+    .message {
+      font-size: 16px;
+      color: #444444;
+      margin-bottom: 32px;
+    }
+
+    .btn {
+      display: inline-block;
+      padding: 12px 28px;
+      background-color: #4f46e5;
+      color: #ffffff;
+      font-weight: 500;
+      text-decoration: none;
+      border-radius: 8px;
+      transition: background-color 0.3s ease;
+    }
+
+    .btn:hover {
+      background-color: #3730a3;
+    }
+  </style>
+</head>
+<body>
+<div class="container">
+  <div class="title">이메일 인증 완료 ✅</div>
+  <div class="message">이제 Threadly의 모든 기능을 사용할 수 있어요!<br>지금 바로 로그인 해보세요.</div>
+  <a href="https://threadly.com/login" class="btn">로그인 하러 가기</a>
+</div>
+</body>
+</html>

--- a/notification-core/core-service/src/main/resources/templates/verify-email-mail.html
+++ b/notification-core/core-service/src/main/resources/templates/verify-email-mail.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <html lang="ko">
+  <head>
+    <meta charset="UTF-8"/>
+    <title>Threadly 이메일 인증</title>
+  </head>
+  <body style="font-family: Arial, sans-serif; background-color: #f9f9f9; padding: 30px;">
+
+  <table width="100%" cellpadding="0" cellspacing="0" border="0"
+         style="max-width: 600px; margin: auto; background-color: #ffffff; border: 1px solid #e0e0e0; border-radius: 10px; overflow: hidden;">
+    <tr>
+      <td style="padding: 30px 40px;">
+        <h2 style="margin: 0 0 20px 0; color: #333333;">👋 Threadly에 오신 걸 환영합니다.</h2>
+        <p style="font-size: 16px; color: #555555; line-height: 1.6;">
+          안녕하세요, <strong>Threadly</strong>입니다.<br/>
+          회원가입을 완료하시려면 아래 버튼을 눌러 이메일 인증을 완료해주세요.
+        </p>
+
+        <!--            이메일 인증하기-->
+        <div style="text-align: center; margin: 30px 0;">
+          <a th:href="${verifyUrl}"
+             style="background-color: #4f46e5; color: white; padding: 14px 24px; text-decoration: none; font-size: 16px; border-radius: 6px; display: inline-block;">
+            이메일 인증하기
+          </a>
+          </a>
+
+        </div>
+
+        <p style="font-size: 14px; color: #999999;">
+          만약 버튼이 작동하지 않는다면 아래 주소를 브라우저에 직접 입력해 주세요:<br/>
+          <a th:text="${verifyUrl}"
+             style="color: #4f46e5;">${verifyUrl}</a>
+        </p>
+
+        <hr style="margin: 30px 0; border: none; border-top: 1px solid #eeeeee;"/>
+
+        <p style="font-size: 12px; color: #cccccc;">
+          본 메일은 발신 전용입니다. 문의는 threadly.com 고객센터를 이용해주세요.
+        </p>
+      </td>
+    </tr>
+  </table>
+
+  </body>
+  </html>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,7 @@ pluginManagement {
     include("notification-adapters:adapter-redis")
     include("notification-adapters:adapter-persistence")
     include("notification-adapters:adapter-kafka")
+    include("notification-adapters:adapter-smtp")
 
     include("notification-apps:app-api")
 


### PR DESCRIPTION
## 개요
- 알림 서비스에 메일 전송 기능을 추가하여 사용자에게 이메일을 통한 알림 제공
- Kafka 메시지를 수신하여 SMTP를 통한 메일 발송 기능 구현

## 주요 변경 사항
- `adapter-smtp` 모듈 신규 생성 및 메일 전송 기능 구현
  - `MailClient`: SMTP를 통한 메일 발송 클라이언트 구현
  - `SmtpModule`: SMTP 어댑터 모듈 설정
- `core-domain`에 메일 도메인 모델 추가
  - `MailModel`, `VerificationModel`, `WelcomeModel`: 메일 타입별 도메인 모델
  - `MailType`: 메일 타입 정의 (VERIFICATION, WELCOME)
- `core-port`에 메일 전송 관련 포트 인터페이스 추가
  - `SendMailUseCase`: 메일 전송 유스케이스 인터페이스
  - `SendMailPort`: 메일 전송 포트 인터페이스
  - `SendMailCommand`: 메일 전송 명령 DTO
- `core-service`에 메일 전송 서비스 구현
  - `SendMailService`: 메일 전송 비즈니스 로직 구현
  - `MailModelMapper`: 메일 이벤트를 도메인 모델로 변환하는 매퍼
  - HTML 템플릿 추가 (이메일 인증, 가입 완료, 인증 완료 페이지)
- `adapter-kafka`에 메일 이벤트 컨슈머 추가
  - `MailConsumer`: Kafka에서 메일 이벤트 수신 및 처리
  - `MailEvent`: 메일 이벤트 DTO

## 고려사항
- SMTP 설정은 환경별 설정 파일을 통해 관리 필요
- 메일 전송 실패 시 재시도 로직 및 Dead Letter Queue 처리 방안 검토 필요