### PR TITLE
docs:TLY-115 swagger 적용

### DIFF
--- a/notification-apps/app-api/build.gradle.kts
+++ b/notification-apps/app-api/build.gradle.kts
@@ -17,7 +17,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("io.micrometer:micrometer-registry-prometheus")
-    implementation ("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
 
 
     testImplementation("io.jsonwebtoken:jjwt-api")

--- a/notification-apps/app-api/src/main/java/com/threadly/notification/advice/ResponseWrapperAdvice.java
+++ b/notification-apps/app-api/src/main/java/com/threadly/notification/advice/ResponseWrapperAdvice.java
@@ -25,7 +25,12 @@ public class ResponseWrapperAdvice implements ResponseBodyAdvice<Object> {
       MediaType selectedContentType, Class<? extends HttpMessageConverter<?>> selectedConverterType,
       ServerHttpRequest request, ServerHttpResponse response) {
     String path = request.getURI().getPath();
-    if (path.startsWith("/actuator")) {
+    
+    // Actuator와 Swagger 관련 경로는 래핑하지 않음
+    if (path.startsWith("/actuator") || 
+        path.startsWith("/swagger-ui") || 
+        path.startsWith("/v3/api-docs") ||
+        path.equals("/swagger-ui.html")) {
       return body;
     }
 

--- a/notification-apps/app-api/src/main/java/com/threadly/notification/config/OpenApiConfig.java
+++ b/notification-apps/app-api/src/main/java/com/threadly/notification/config/OpenApiConfig.java
@@ -1,0 +1,38 @@
+package com.threadly.notification.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    return new OpenAPI()
+        .info(new Info().title("Threadly Notification-Service API")
+            .version("v1")
+            .description("Threadly Notification-Service API 명세"))
+        .components(
+            new Components().addSecuritySchemes("bearerAuth",
+                new SecurityScheme().type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("JWT")))
+        .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
+
+  }
+  @Bean
+  public GroupedOpenApi notificationsApi() {
+    return GroupedOpenApi.builder()
+        .group("notifications")
+        .packagesToScan("com.threadly.notification.controller")
+        .pathsToMatch("/api/notifications/**")
+        .build();
+  }
+
+}

--- a/notification-apps/app-api/src/main/java/com/threadly/notification/config/SecurityConfig.java
+++ b/notification-apps/app-api/src/main/java/com/threadly/notification/config/SecurityConfig.java
@@ -65,6 +65,9 @@ public class SecurityConfig {
             .requestMatchers(
                 "/actuator/**",
                 "/api/test/kafka",
+                "/swagger-ui.html",
+                "/swagger-ui/**",
+                "/v3/api-docs/**",
                 "/ws/**")
             .permitAll()
             .anyRequest().authenticated()

--- a/notification-apps/app-api/src/main/java/com/threadly/notification/controller/NotificationController.java
+++ b/notification-apps/app-api/src/main/java/com/threadly/notification/controller/NotificationController.java
@@ -1,11 +1,14 @@
 package com.threadly.notification.controller;
 
 import com.threadly.notification.auth.JwtAuthenticationUser;
+import com.threadly.notification.commons.response.ApiResponse;
 import com.threadly.notification.commons.response.CursorPageApiResponse;
+import com.threadly.notification.controller.api.NotificationApi;
 import com.threadly.notification.core.port.notification.in.NotificationCommandUseCase;
 import com.threadly.notification.core.port.notification.in.NotificationQueryUseCase;
 import com.threadly.notification.core.port.notification.in.dto.GetNotificationDetailsApiResponse;
 import com.threadly.notification.core.port.notification.in.dto.GetNotificationsQuery;
+import com.threadly.notification.core.port.notification.in.dto.NotificationDetails;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/notifications")
 @RequiredArgsConstructor
-public class NotificationController {
+public class NotificationController implements NotificationApi {
 
   private final NotificationQueryUseCase notificationQueryUseCase;
   private final NotificationCommandUseCase notificationCommandUseCase;
@@ -37,7 +40,7 @@ public class NotificationController {
    * @return
    */
   @GetMapping()
-  public ResponseEntity<CursorPageApiResponse> getNotifications(
+  public ResponseEntity<CursorPageApiResponse<NotificationDetails>> getNotifications(
       @AuthenticationPrincipal JwtAuthenticationUser user,
       @RequestParam(value = "cursor_timestamp", required = false) LocalDateTime cursorTimestamp,
       @RequestParam(value = "cursor_id", required = false) String cursorId,
@@ -53,6 +56,7 @@ public class NotificationController {
 
   /**
    * 읽지 않은 알림 목록 커서 기반 조회
+   *
    * @param user
    * @param cursorTimestamp
    * @param cursorId
@@ -60,7 +64,7 @@ public class NotificationController {
    * @return
    */
   @GetMapping("/unread")
-  public ResponseEntity<CursorPageApiResponse> getUnreadNotifications(
+  public ResponseEntity<CursorPageApiResponse<NotificationDetails>> getUnreadNotifications(
       @AuthenticationPrincipal JwtAuthenticationUser user,
       @RequestParam(value = "cursor_timestamp", required = false) LocalDateTime cursorTimestamp,
       @RequestParam(value = "cursor_id", required = false) String cursorId,
@@ -145,7 +149,6 @@ public class NotificationController {
     notificationCommandUseCase.clearNotifications(user.getUserId());
     return ResponseEntity.ok().build();
   }
-
 
 
 }

--- a/notification-apps/app-api/src/main/java/com/threadly/notification/controller/api/NotificationApi.java
+++ b/notification-apps/app-api/src/main/java/com/threadly/notification/controller/api/NotificationApi.java
@@ -1,0 +1,213 @@
+package com.threadly.notification.controller.api;
+
+import com.threadly.notification.auth.JwtAuthenticationUser;
+import com.threadly.notification.commons.response.CursorPageApiResponse;
+import com.threadly.notification.core.port.notification.in.dto.GetNotificationDetailsApiResponse;
+import com.threadly.notification.core.port.notification.in.dto.NotificationDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "알림 API", description = "사용자 알림 관련 API")
+public interface NotificationApi {
+
+  /**
+   * 내 전체 알림 목록 커서 기반 조회
+   */
+  @Operation(summary = "전체 알림 목록 커서 기반 조회", 
+             description = "사용자의 모든 알림을 커서 기반 페이지네이션으로 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "알림 목록 조회 성공",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = CursorPageApiResponse.class),
+              examples = @ExampleObject(
+                  name = "알림 목록 응답 예시",
+                  value = """
+                      {
+                        "content": [
+                          {
+                            "eventId": "event-12345",
+                            "sortId": "sort-98765",
+                            "receiverId": "user123",
+                            "notificationType": "POST_LIKE",
+                            "occurredAt": "2024-01-15T10:30:00",
+                            "actorProfile": {
+                              "userId": "actor-user-456",
+                              "nickname": "좋아요누른사용자",
+                              "profileImageUrl": "https://example.com/profile/456.jpg"
+                            },
+                            "isRead": false
+                          }
+                        ],
+                        "nextCursor": {
+                          "cursorTimestamp": "2024-01-15T10:29:00",
+                          "cursorId": "sort-98764"
+                        }
+                      }
+                      """
+              )
+          )),
+      @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+      @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
+  })
+  @GetMapping
+  ResponseEntity<CursorPageApiResponse<NotificationDetails>> getNotifications(
+      @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthenticationUser user,
+      @Parameter(description = "커서 타임스탬프 (이전 페이지의 마지막 항목 시간)", example = "2024-01-01T10:00:00")
+      @RequestParam(value = "cursor_timestamp", required = false) LocalDateTime cursorTimestamp,
+      @Parameter(description = "커서 ID (이전 페이지의 마지막 항목 ID)", example = "notification-123")
+      @RequestParam(value = "cursor_id", required = false) String cursorId,
+      @Parameter(description = "한 페이지당 조회할 알림 개수", example = "10")
+      @RequestParam(value = "limit", defaultValue = "10") int limit);
+
+  /**
+   * 읽지 않은 알림 목록 커서 기반 조회
+   */
+  @Operation(summary = "읽지 않은 알림 목록 커서 기반 조회", 
+             description = "사용자의 읽지 않은 알림만을 커서 기반 페이지네이션으로 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "읽지 않은 알림 목록 조회 성공",
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = CursorPageApiResponse.class),
+              examples = @ExampleObject(
+                  name = "읽지 않은 알림 목록 응답 예시",
+                  value = """
+                      {
+                        "content": [
+                          {
+                            "eventId": "unread-event-12345",
+                            "sortId": "sort-98765",
+                            "receiverId": "user123",
+                            "notificationType": "POST_LIKE",
+                            "occurredAt": "2024-01-15T10:30:00",
+                            "actorProfile": {
+                              "userId": "actor-user-456",
+                              "nickname": "새로운좋아요",
+                              "profileImageUrl": "https://example.com/profile/456.jpg"
+                            },
+                            "isRead": false
+                          }
+                        ],
+                        "nextCursor": {
+                          "cursorTimestamp": "2024-01-15T10:29:00",
+                          "cursorId": "sort-98764"
+                        }
+                      }
+                      """
+              )
+          )),
+      @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+      @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content)
+  })
+  @GetMapping("/unread")
+  ResponseEntity<CursorPageApiResponse<NotificationDetails>> getUnreadNotifications(
+      @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthenticationUser user,
+      @Parameter(description = "커서 타임스탬프 (이전 페이지의 마지막 항목 시간)", example = "2024-01-01T10:00:00")
+      @RequestParam(value = "cursor_timestamp", required = false) LocalDateTime cursorTimestamp,
+      @Parameter(description = "커서 ID (이전 페이지의 마지막 항목 ID)", example = "notification-123")
+      @RequestParam(value = "cursor_id", required = false) String cursorId,
+      @Parameter(description = "한 페이지당 조회할 알림 개수", example = "10")
+      @RequestParam(value = "limit", defaultValue = "10") int limit
+  );
+
+
+  /**
+   * 주어진 eventId에 해당하는 알림 조회
+   */
+  @Operation(summary = "알림 상세 조회", 
+             description = "특정 eventId에 해당하는 알림의 상세 정보를 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "알림 상세 조회 성공",
+          content = @Content(schema = @Schema(implementation = GetNotificationDetailsApiResponse.class))),
+      @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+      @ApiResponse(responseCode = "403", description = "해당 알림에 대한 접근 권한 없음", content = @Content),
+      @ApiResponse(responseCode = "404", description = "알림을 찾을 수 없음", content = @Content)
+  })
+  @GetMapping("/{eventId}")
+  ResponseEntity<GetNotificationDetailsApiResponse> getNotificationDetail(
+      @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthenticationUser user,
+      @Parameter(description = "알림 이벤트 ID", example = "event-12345", required = true)
+      @PathVariable String eventId
+  );
+
+  /**
+   * 주어진 eventId에 해당하는 알림 읽음 처리
+   */
+  @Operation(summary = "알림 읽음 처리", 
+             description = "특정 알림을 읽음 상태로 변경합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "알림 읽음 처리 성공", content = @Content),
+      @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+      @ApiResponse(responseCode = "403", description = "해당 알림에 대한 접근 권한 없음", content = @Content),
+      @ApiResponse(responseCode = "404", description = "알림을 찾을 수 없음", content = @Content)
+  })
+  @PatchMapping("/{eventId}/read")
+  ResponseEntity<Void> markAsRead(
+      @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthenticationUser user,
+      @Parameter(description = "알림 이벤트 ID", example = "event-12345", required = true)
+      @PathVariable String eventId
+  );
+
+  /**
+   * 전체 알림 목록 읽음 처리
+   */
+  @Operation(summary = "전체 알림 읽음 처리", 
+             description = "사용자의 모든 알림을 읽음 상태로 변경합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "전체 알림 읽음 처리 성공", content = @Content),
+      @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+  })
+  @PatchMapping("/read-all")
+  ResponseEntity<Void> markAllAsRead(
+      @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthenticationUser user
+  );
+
+  /**
+   * 주어진 eventId에 해당하는 알림 삭제
+   */
+  @Operation(summary = "알림 삭제", 
+             description = "특정 알림을 영구적으로 삭제합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "알림 삭제 성공", content = @Content),
+      @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+      @ApiResponse(responseCode = "403", description = "해당 알림에 대한 접근 권한 없음", content = @Content),
+      @ApiResponse(responseCode = "404", description = "알림을 찾을 수 없음", content = @Content)
+  })
+  @DeleteMapping("/{eventId}")
+  ResponseEntity<Void> deleteNotification(
+      @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthenticationUser user,
+      @Parameter(description = "알림 이벤트 ID", example = "event-12345", required = true)
+      @PathVariable String eventId
+  );
+
+  /**
+   * 전체 알림 목록 삭제
+   */
+  @Operation(summary = "전체 알림 삭제", 
+             description = "사용자의 모든 알림을 영구적으로 삭제합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "전체 알림 삭제 성공", content = @Content),
+      @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+  })
+  @DeleteMapping
+  ResponseEntity<Void> deleteAllNotifications(
+      @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthenticationUser user
+  );
+
+
+}

--- a/notification-apps/app-api/src/main/java/com/threadly/notification/global/filter/FilterBypassMatcher.java
+++ b/notification-apps/app-api/src/main/java/com/threadly/notification/global/filter/FilterBypassMatcher.java
@@ -11,6 +11,9 @@ public class FilterBypassMatcher {
   public static final List<String> WHITE_LIST = List.of(
       "/actuator/**",
       "/api/test/kafka",
+      "/swagger-ui.html",
+      "/swagger-ui/**",
+      "/v3/api-docs/**",
       "/ws/**"
   );
 

--- a/notification-commons/build.gradle.kts
+++ b/notification-commons/build.gradle.kts
@@ -8,7 +8,6 @@ dependencies {
 
 
     implementation("org.springframework:spring-context")
-
     implementation("org.springframework.boot:spring-boot-starter-web")
 
 }

--- a/notification-core/core-port/build.gradle.kts
+++ b/notification-core/core-port/build.gradle.kts
@@ -3,5 +3,6 @@ dependencies {
     implementation(project(":notification-commons"))
 
     implementation("com.fasterxml.jackson.core:jackson-annotations")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
 
 }

--- a/notification-core/core-port/src/main/java/com/threadly/notification/core/port/notification/in/NotificationQueryUseCase.java
+++ b/notification-core/core-port/src/main/java/com/threadly/notification/core/port/notification/in/NotificationQueryUseCase.java
@@ -3,6 +3,7 @@ package com.threadly.notification.core.port.notification.in;
 import com.threadly.notification.commons.response.CursorPageApiResponse;
 import com.threadly.notification.core.port.notification.in.dto.GetNotificationDetailsApiResponse;
 import com.threadly.notification.core.port.notification.in.dto.GetNotificationsQuery;
+import com.threadly.notification.core.port.notification.in.dto.NotificationDetails;
 
 /**
  * Notification 조회 관련 usecase
@@ -22,14 +23,14 @@ public interface NotificationQueryUseCase {
    * @param query
    * @return
    */
-  CursorPageApiResponse findNotificationByCursor(GetNotificationsQuery query);
+  CursorPageApiResponse<NotificationDetails> findNotificationByCursor(GetNotificationsQuery query);
 
   /**
    * 읽지 않은 알림 목록 커서 기반 조회
    * @param query
    * @return
    */
-  CursorPageApiResponse findUnreadNotificationByCursor(GetNotificationsQuery query);
+  CursorPageApiResponse<NotificationDetails> findUnreadNotificationByCursor(GetNotificationsQuery query);
 
 
 }

--- a/notification-core/core-port/src/main/java/com/threadly/notification/core/port/notification/in/dto/GetNotificationDetailsApiResponse.java
+++ b/notification-core/core-port/src/main/java/com/threadly/notification/core/port/notification/in/dto/GetNotificationDetailsApiResponse.java
@@ -12,11 +12,13 @@ import com.threadly.notification.core.domain.notification.metadata.FollowRequest
 import com.threadly.notification.core.domain.notification.metadata.NotificationMetaData;
 import com.threadly.notification.core.domain.notification.metadata.PostCommentMeta;
 import com.threadly.notification.core.domain.notification.metadata.PostLikeMeta;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 /**
  * Notification 상세 조회 API 응답 객체
  */
+@Schema(description = "알림 상세 조회 응답")
 public record GetNotificationDetailsApiResponse(
     String eventId,
     String receiverId,

--- a/notification-core/core-service/src/main/java/com/threadly/notification/core/service/notification/NotificationQueryQueryService.java
+++ b/notification-core/core-service/src/main/java/com/threadly/notification/core/service/notification/NotificationQueryQueryService.java
@@ -63,7 +63,7 @@ public class NotificationQueryQueryService implements NotificationQueryUseCase {
 
   @Transactional(readOnly = true)
   @Override
-  public CursorPageApiResponse findUnreadNotificationByCursor(GetNotificationsQuery query) {
+  public CursorPageApiResponse<NotificationDetails> findUnreadNotificationByCursor(GetNotificationsQuery query) {
     List<NotificationDetails> notifications = notificationQueryPort.fetchUnreadByCursor(query);
     return CursorPageApiResponse.from(notifications, query.limit());
   }


### PR DESCRIPTION
## 개요
-  API 문서화를 위한 Swagger UI 적용

## 주요 변경 사항
- `app-api` 모듈에 Swagger 설정 추가
  - `OpenApiConfig`: OpenAPI 설정 및 JWT 보안 스키마 구성
  - `GroupedOpenApi`: 알림 API 그룹 분리
- `NotificationApi` 인터페이스 생성 및 Swagger 애노테이션 적용
  - `@Operation`: 각 API 엔드포인트별 상세 설명
  - `@ApiResponses`: HTTP 상태코드별 응답 명세
  - `@Parameter`: 요청 파라미터 설명 및 예시값
  - `@ExampleObject`: 응답 JSON 예시 데이터 제공
- 최상위 응답 DTO에 `@Schema` 애노테이션 추가
- `ResponseWrapperAdvice`에서 Swagger 경로 제외 처리
  - `/swagger-ui/**`, `/v3/api-docs/**` 경로를 ResponseBodyAdvice 래핑에서 제외


## 고려사항
- JWT 인증이 필요한 API는 Swagger UI에서 "Authorize" 버튼을 통해 토큰 설정 필요
- 응답 예시는 실제 비즈니스 로직과 일치하도록 주기적 업데이트 필요